### PR TITLE
add affiliation to maintainer section

### DIFF
--- a/content/en/about/index.md
+++ b/content/en/about/index.md
@@ -31,21 +31,21 @@ Open Source Community. Here are our current illustrious leaders:
 
 {{< cardpane >}}
 
-{{< card header="**Dan Rollo**" >}}
+{{< card header="**Dan Rollo** (External Contributor)" >}}
 
 {{% imgproc dan-rollo Resize "400x400" %}}
 {{% /imgproc %}}
 
 {{< /card >}}
 
-{{< card header="**Eddie Knight**" >}}
+{{< card header="**Eddie Knight** (Sonatyper)" >}}
 
 {{% imgproc eddie-knight Resize "400x400" %}}
 {{% /imgproc %}}
 
 {{< /card >}}
 
-{{< card header="**Paul Horton**" >}}
+{{< card header="**Paul Horton** (Sonatyper)" >}}
 
 {{% imgproc paul-horton Resize "400x400" %}}
 {{% /imgproc %}}


### PR DESCRIPTION
Add affiliation note to maintainers info.

Does this cover it?
<img width="1631" height="1159" alt="Screenshot 2025-08-21 at 12 50 30 PM" src="https://github.com/user-attachments/assets/135d3788-ac30-482e-9fcb-5306e991d0f6" />
